### PR TITLE
Fix/mobile display

### DIFF
--- a/src/assets/icons/exports.jsx
+++ b/src/assets/icons/exports.jsx
@@ -76,3 +76,13 @@ export const StarIcon = ({ className }) => {
     </svg>
   )
 }
+
+export const InfoIcon = ({ className }) => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={`${className || ''}`}>
+      <circle cx="12" cy="12" r="10"/>
+      <path d="M12 16v-4"/>
+      <path d="M12 8h.01"/>
+    </svg>
+  )
+}

--- a/src/components/DiscoverCard.jsx
+++ b/src/components/DiscoverCard.jsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from "react";
-import { LikeIcon, PassIcon, RejectIcon, HeartIcon } from '@icons';
+import { LikeIcon, PassIcon, RejectIcon, HeartIcon, InfoIcon } from '@icons';
+import MovieModal from "./common/MovieModal";
+import { useModal } from "@hooks/useModal";
 
 const DiscoverCard = ({ movie, onSwipe, isLoading}) => {
   const [currentX, setCurrentX] = useState(0);
@@ -8,6 +10,7 @@ const DiscoverCard = ({ movie, onSwipe, isLoading}) => {
   const [swipeDirection, setSwipeDirection] = useState(null); // 'left' or 'right'
   const isProcessingSwipe = useRef(false);
   const cardRef = useRef(null);
+  const { modalId, openModal, closeModal } = useModal();
 
 const handleDragStart = (e) => {
   setIsDragging(true);
@@ -93,7 +96,7 @@ const handleSubmit = (e) => {
   };
 
   return (
-    <div className="flex justify-center items-center max-w-md mx-auto p-4 absolute top-0 left-0 right-0 bottom-0" >
+    <div className="flex justify-center items-center max-w-md mx-auto p-4 absolute top-0 left-0 right-0 bottom-0 fade-in" >
       <div ref={cardRef} style={{ transform: `translateX(${currentX}px) rotate(${currentX * 0.1}deg)` }} onMouseDown={handleMouseDown} onTouchStart={handleTouchStart} className={`relative rounded-2xl duration-0 touch-none ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}>
         <div className={`rounded-2xl border-2 ${swipeDirection === 'right' ? 'border-green-500' : swipeDirection === 'left' ? 'border-red-500' : ''}`}>
         <div className={`flex items-center justify-center absolute top-0 left-0 right-0 bottom-0 rounded-2xl transition-opacity duration-300 ${swipeDirection === 'right' ? 'bg-green-500/25' : swipeDirection === 'left' ? 'bg-red-500/25' : ''}`}>
@@ -101,13 +104,17 @@ const handleSubmit = (e) => {
         </div>
         <div>
           <img className="rounded-2xl aspect-2/3 object-cover bg-primary-400" src={movie.poster} alt="Movie Poster" />
-          <div className={`flex flex-row absolute bottom-0 left-0 right-0 justify-center items-end gap-4 h-full py-4 opacity-0 hover:opacity-100 text-white rounded-2xl `}>
-            <button onClick={handleSubmit} disabled={isProcessingSwipe.current} className="rounded-full w-16 h-16 bg-error-500 " value="left"><PassIcon /></button>
-            <button onClick={handleSubmit} disabled={isProcessingSwipe.current} className="rounded-full w-16 h-16 bg-success-500 " value="right"><LikeIcon /></button>
+          <div className={`flex flex-row group absolute bottom-0 left-0 right-0 justify-center items-end gap-4 h-full py-4 opacity-0 hover:opacity-100 text-white rounded-2xl `}>
+            <button onClick={handleSubmit} disabled={isProcessingSwipe.current} className="hidden group-hover:flex rounded-full w-16 h-16 bg-error-500 " value="left"><PassIcon /></button>
+            <button onClick={handleSubmit} disabled={isProcessingSwipe.current} className="hidden group-hover:flex rounded-full w-16 h-16 bg-success-500 " value="right"><LikeIcon /></button>
           </div>
+          <button onClick={() => openModal(movie.id)} className="absolute top-4 right-4 h-10 w-10 p-0 rounded-full text-white bg-transparent z-50" aria-label={`Explore details for ${movie.title}`}>
+            <InfoIcon className="w-8 h-8 bg-secondary-500 rounded-full" />
+          </button>
         </div>
         </div>
       </div>
+      <MovieModal movie={movie} isOpen={modalId === movie.id} closeModal={closeModal} />
     </div>
   );
 };

--- a/src/components/WatchListFilter.jsx
+++ b/src/components/WatchListFilter.jsx
@@ -84,7 +84,7 @@ const WatchListFilter = ({ activeFilters, setActiveFilters, searchTerm, setSearc
 					/>
 				</form>
 				{filters.map((filter) => (
-					<div key={filter.categoryName} className="flex flex-col justify-center relative">
+					<div key={filter.categoryName} className="popover flex flex-col justify-center relative">
 						<div className="flex flex-row justify-between items-center">
 							<h4 className="m-0" id={`filter-label-${filter.categoryName}`}>{filter.categoryName}</h4>
 							<button

--- a/src/components/WatchListGrid.jsx
+++ b/src/components/WatchListGrid.jsx
@@ -1,6 +1,9 @@
-import { CloseIcon } from '@icons';
+import { CloseIcon, InfoIcon } from '@icons';
+import useModal from '@hooks/useModal';
+import MovieModal from './common/MovieModal';
 
-const WatchListGrid = ({movies, removeLikedMovie, openModal}) => {
+const WatchListGrid = ({movies, removeLikedMovie }) => {
+  const { modalId, openModal, closeModal } = useModal();
 
   if (!movies || movies.length === 0) {
     return <p>No movies found matching your criteria.</p>;
@@ -13,14 +16,18 @@ const WatchListGrid = ({movies, removeLikedMovie, openModal}) => {
       aria-label="Watchlist movies grid"
     >
       {movies.map((movie) => (
-        <div className="grid-cols-2 gap-2" key={movie.id || movie.title} role="row">
+        <div className="group grid-cols-2 gap-2" key={movie.id || movie.title} role="row">
           <div className="relative aspect-2/3 bg-primary-400 rounded-2xl" role="gridcell" aria-labelledby={`movie-title-${movie.id}`}> 
             <img
               className="rounded-2xl w-full h-full object-cover"
               src={movie.poster}
               alt={`Poster for ${movie.title}`}
+              onClick={() => openModal(movie.id)}
             />
-            <div className="flex flex-col absolute top-0 left-0 w-full h-full p-4 justify-between opacity-0 hover:opacity-100 bg-blur text-white rounded-2xl border-1 border-primary-300">
+            <button onClick={() => removeLikedMovie(movie)} className="absolute md:hidden top-2 right-2 h-6 w-6 p-0 rounded-full bg-transparent text-error-500" aria-label={`Remove ${movie.title} from watchlist`}>
+              <CloseIcon className="w-6 h-6 rounded-full" />
+            </button>
+            <div className="hidden group-hover:flex flex-col absolute top-0 left-0 w-full h-full p-4 justify-between opacity-0  hover:opacity-100 bg-blur text-white rounded-2xl border-1 border-primary-300">
               <div className="flex flex-row justify-between items-start gap-4">
                 <div>
                   <h3 id={`movie-title-${movie.id}`}>{movie.title}</h3>
@@ -47,10 +54,15 @@ const WatchListGrid = ({movies, removeLikedMovie, openModal}) => {
               </div>
             </div>
           </div>
+          <MovieModal
+            movie={movie}
+            isOpen={modalId === movie.id}
+            closeModal={closeModal}
+          />
         </div>
       ))}
     </div>
   );
 };
 
-export default  WatchListGrid;
+export default WatchListGrid;

--- a/src/components/common/MovieModal.jsx
+++ b/src/components/common/MovieModal.jsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { CloseIcon, StarIcon } from '@icons';
 
 
-const WatchListModal = ({ movie, closeModal }) => {
+const MovieModal = ({ movie, isOpen, closeModal }) => {
+
 	return (
-		<div className="modal-overlay w-full h-full fixed top-0 left-0 flex items-center justify-center bg-black/50 backdrop-blur-xs">
+		<div className={`modal-overlay w-full h-full fixed top-0 left-0 flex items-center justify-center z-40 bg-black/50 backdrop-blur-xs fade-in ${isOpen ? 'block' : 'hidden'}`}>
 			<div
 				className="modal-content max-w-4xl mx-4 bg-primary-500/90 border-2 rounded-2xl shadow-lg relative"
 				role="dialog"
@@ -12,12 +14,14 @@ const WatchListModal = ({ movie, closeModal }) => {
 				aria-describedby="watchlist-modal-desc"
 			>
 				<div className="flex flex-col md:flex-row gap-4">
-					<img
-						className="w-full md:w-1/2 rounded-xl absolute md:static md:rounded-r aspect-2/3"
-						src={movie.poster}
-						alt={`Poster for ${movie.title}`}
-					/>
-					<div className="flex flex-col md:w-1/2 inset-0 z-10 bg-gradient-to-t aspect-2/3 from-black via-black/90 to-transparent md:bg-none rounded-b-xl py-8 p-4 gap-2">
+					<div className="absolute md:static w-full md:w-1/2 aspect-2/3">
+						<img
+							className="w-full h-full object-cover rounded-xl inset-0"
+							src={movie.poster}
+							alt={`Poster for ${movie.title}`}
+						/>
+					</div>
+					<div className="flex flex-col justify-end md:justify-start md:w-1/2 z-50 bg-gradient-to-t aspect-2/3 from-black via-black/90 to-transparent md:bg-none rounded-b-xl py-8 p-4 gap-2">
 						<div className="border-2 gap-2 flex flex-row justify-start items-center border-primary-700 bg-primary-700 w-fit p-1 px-2 rounded-full">
 							<StarIcon className="w-4 h-4 text-accent-500" />
 							<p className="text-sm text-white">{movie.rating.toFixed(1)} </p>
@@ -45,4 +49,4 @@ const WatchListModal = ({ movie, closeModal }) => {
 	);
 };
 
-export default WatchListModal;
+export default MovieModal;

--- a/src/components/common/Slider.jsx
+++ b/src/components/common/Slider.jsx
@@ -86,7 +86,7 @@ const maxPosition = valueToPosition(range.max);
       <div className="slider-track-container mt-4">
         <div 
           ref={sliderRef}
-          className="slider-track relative h-2 bg-gray-200 rounded-full cursor-pointer"
+          className="slider-track relative h-8 bg-gray-200 rounded-full cursor-pointer"
           onClick={(e) => {
             if (dragState.isDragging) return;
 
@@ -113,7 +113,7 @@ const maxPosition = valueToPosition(range.max);
             }} 
           />
           <div 
-            className={`slider-handle-min absolute top-1/2 transform -translate-y-1/2 -translate-x-2.5 w-5 h-5 bg-white border-2 border-accent-500 rounded-full cursor-grab
+            className={`slider-handle-min touch-none absolute top-1/2 transform -translate-y-1/2 -translate-x-2.5 w-8 h-8 bg-white border-2 border-accent-500 rounded-full cursor-grab
                shadow-md transition-transform
               ${dragState.isDragging && dragState.dragType === 'min' ? 'cursor-grabbing' : ''}`}
             style={{ left: `${minPosition}%` }}
@@ -121,7 +121,7 @@ const maxPosition = valueToPosition(range.max);
             onTouchStart={(e) => handleDragStart(e, 'min')}
           />
           <div 
-            className={`slider-handle-max absolute w-5 h-5 bg-white border-2 border-accent-500 rounded-full cursor-grab
+            className={`slider-handle-max touch-none absolute w-8 h-8 bg-white border-2 border-accent-500 rounded-full cursor-grab
               top-1/2 transform -translate-y-1/2 translate-x-2.5 shadow-md transition-transform hover:scale-110
               ${dragState.isDragging && dragState.dragType === 'max' ? 'cursor-grabbing' : ''}`}
             style={{ right: `${ 100 - maxPosition}%` }}

--- a/src/components/common/Slider.jsx
+++ b/src/components/common/Slider.jsx
@@ -98,10 +98,17 @@ const maxPosition = valueToPosition(range.max);
             const distanceToMin = Math.abs(clickValue - range.min);
             const distanceToMax = Math.abs(clickValue - range.max);
 
+            let newRange;
             if (distanceToMin < distanceToMax) {
-              setRange(prev => ({...prev, min: Math.min(clickValue, prev.max)}));
+              newRange = {...range, min: Math.min(clickValue, range.max)};
             } else {
-              setRange(prev => ({...prev, max: Math.max(clickValue, prev.min)}));
+              newRange = {...range, max: Math.max(clickValue, range.min)};
+            }
+
+            setRange(newRange);
+          
+            if (onChange && (newRange.min !== range.min || newRange.max !== range.max)) {
+              onChange(newRange);
             }
           }}
         >
@@ -122,7 +129,7 @@ const maxPosition = valueToPosition(range.max);
           />
           <div 
             className={`slider-handle-max touch-none absolute w-8 h-8 bg-white border-2 border-accent-500 rounded-full cursor-grab
-              top-1/2 transform -translate-y-1/2 translate-x-2.5 shadow-md transition-transform hover:scale-110
+              top-1/2 transform -translate-y-1/2 translate-x-2.5 shadow-md transition-transform
               ${dragState.isDragging && dragState.dragType === 'max' ? 'cursor-grabbing' : ''}`}
             style={{ right: `${ 100 - maxPosition}%` }}
             onMouseDown={(e) => handleDragStart(e, 'max')}

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+export const useModal = () => {
+  const [modalId, setModalId] = useState(null);
+
+  // Modal logic
+  const openModal = (id) => setModalId(id);
+  const closeModal = () => setModalId(null);
+
+  return { modalId, openModal, closeModal };
+}
+
+export default useModal;

--- a/src/pages/WatchList.jsx
+++ b/src/pages/WatchList.jsx
@@ -6,14 +6,12 @@ import Footer from "@components/common/Footer";
 import WatchListGrid from "@components/WatchListGrid";
 import WatchListFilter from "@components/WatchListFilter";
 import WatchListPagination from "@components/WatchListPagination";
-import WatchListModal from "../components/WatchListModal.jsx";
 
 const WatchList = () => {
   const { likedMovies, removeLikedMovie } = useUser();
   const [searchTerm, setSearchTerm] = useState("");
   const [activeFilters, setActiveFilters] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
-  const [modalId, setModalId] = useState(null);
   const ITEMS_PER_PAGE = 24;
 
   // Filtering logic
@@ -70,10 +68,6 @@ const WatchList = () => {
 
   const topRef = useRef(null);
 
-  // Modal logic
-  const openModal = (id) => setModalId(id);
-  const closeModal = () => setModalId(null);
-
   if (!likedMovies || likedMovies.length === 0) {
     return (
       <>
@@ -105,7 +99,6 @@ const WatchList = () => {
           <WatchListGrid
             movies={paginatedMovies}
             removeLikedMovie={removeLikedMovie}
-            openModal={openModal}
           />
           <WatchListPagination
             currentPage={currentPage}
@@ -115,13 +108,6 @@ const WatchList = () => {
             nextPage={nextPage}
             goToPage={goToPage}
           />
-
-          {modalId && (
-            <WatchListModal
-              movie={likedMovies.find(movie => movie.id === modalId)}
-              closeModal={closeModal}
-            />
-          )}
         </div>
       </main>
       <Footer />

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -59,3 +59,15 @@
 
 }
 
+@layer utilities {
+  .fade-in {
+    opacity: 0;
+    animation: fadeIn 0.3s ease-out forwards;
+  }
+
+  @keyframes fadeIn {
+    to {
+      opacity: 1;
+    }
+  }
+}


### PR DESCRIPTION
##Summary
Fine-tunes aspects of mobile experiences by hiding/showing specific buttons based on breakpoints.
##Changes
-Mobile friendly buttons on Watchlist and Discover pages
-Custom hook for useModals to streamline modal button implementation
-Fixed an issue where desktop buttons were clickable on mobile when not displaying