### PR TITLE
feat: Add Authenticated Watchlist Sync Feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
-import UserProvider from '@providers/UserProvider.jsx';
+import WatchlistProvider from '@/providers/WatchlistProvider.js';
 import MovieFeedProvider from '@providers/MovieFeedProvider.jsx';
 import AuthProvider from '@providers/AuthProvider.jsx';
 import MainLayout from '@layouts/MainLayout.jsx';
@@ -21,12 +21,12 @@ const router = createBrowserRouter(
 function App() {
   return (
     <AuthProvider>
-      <UserProvider>
+      <WatchlistProvider>
         <MovieFeedProvider>
           <RouterProvider router={router} />
           <AiChat />
         </MovieFeedProvider>
-      </UserProvider>
+      </WatchlistProvider>
     </AuthProvider>
   )
 }

--- a/src/components/chat/AiChat.tsx
+++ b/src/components/chat/AiChat.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import agentService from '@services/agent.js';
-import { useUser } from '@providers/UserContext';
+import { useWatchlist } from '@/providers/WatchlistContext';
 import movioProfilePic from '@images/ai-avatar.jpg';
 import { ChatBotIcon } from '@icons';
 import type { ChatMessage } from '@/types/chat';
@@ -13,7 +13,7 @@ const AiChat = () => {
   }]);
 	const [inputContent, setInputContent] = useState<string>("");
 	const [isAgentTyping, setIsAgentTyping] = useState<boolean>(false);
-  const { likedMovies } = useUser();
+  const { likedMovies } = useWatchlist();
 
   const movieTitles = useMemo(() => likedMovies.map((movie: Movie) => movie.title).join(", "), [likedMovies]);
 

--- a/src/components/common/MovieModal.jsx
+++ b/src/components/common/MovieModal.jsx
@@ -9,12 +9,11 @@
 
 import { CloseIcon, StarIcon } from '@icons';
 import ScrollableText from "@components/common/ScrollableText";
-import { useUser } from '@providers/UserContext';
+import { useWatchlist } from '@/providers/WatchlistContext';
 
 
 const MovieModal = ({ movie, isOpen, closeModal }) => {
-  const { removeLikedMovie, likedMovies } = useUser();
-
+  const { removeLikedMovie, likedMovies } = useWatchlist();
   if (!isOpen) return null;
 
 	return (

--- a/src/components/common/MovieModal.jsx
+++ b/src/components/common/MovieModal.jsx
@@ -25,8 +25,8 @@ const MovieModal = ({ movie, isOpen, closeModal }) => {
 				className="modal-content max-w-4xl mx-4 bg-primary-500/90 border-2 rounded-2xl shadow-lg relative"
 				role="dialog"
 				aria-modal="true"
-				aria-labelledby={`modal-title-${movie.tmdbId}`}
-				aria-describedby={`modal-desc-${movie.tmdbId}`}
+				aria-labelledby={`modal-title-${movie.id}`}
+				aria-describedby={`modal-desc-${movie.id}`}
 			>
 				<div className="flex flex-col md:flex-row gap-4">
 					<div className="absolute md:static w-full md:w-1/2 aspect-2/3">
@@ -37,14 +37,14 @@ const MovieModal = ({ movie, isOpen, closeModal }) => {
 						/>
 					</div>
 					<div className="flex flex-col justify-end md:justify-start md:w-1/2 z-50 bg-gradient-to-t aspect-2/3 from-black via-black/90 to-transparent md:bg-none rounded-b-xl py-8 p-4 gap-2">
-						{movie.rating && 
+						{movie.ratings && 
               <div className="border-2 gap-2 flex flex-row justify-start items-center border-primary-700 bg-primary-700 w-fit p-1 px-2 rounded-full">
                 <StarIcon className="w-4 h-4 text-accent-500" />
-                <p className="text-sm text-white">{movie.rating.toFixed(1)} </p>
+                <p className="text-sm text-white">{movie.ratings.toFixed(1)} </p>
 						  </div>}
-						<h2 id={`modal-title-${movie.tmdbId}`} className="text-5xl">{movie.title}</h2>
+						<h2 id={`modal-title-${movie.id}`} className="text-5xl">{movie.title}</h2>
 						<p className="text-sm text-white mb-2">{movie.genres.join(", ")}</p>
-						<ScrollableText id={`modal-desc-${movie.tmdbId}`}>{movie.description}</ScrollableText>
+						<ScrollableText id={`modal-desc-${movie.id}`}>{movie.description}</ScrollableText>
 						<div className="flex flex-row flex-wrap justify-start items-start gap-2 mt-4">
 							<button className="w-full border-2 border-secondary-500"
                 aria-label={`Watch ${movie.title}`}>

--- a/src/components/discover/DiscoverCard.jsx
+++ b/src/components/discover/DiscoverCard.jsx
@@ -86,12 +86,12 @@ const DiscoverCard = ({ movie, onSwipe, isLoading, style, isTopCard = true, card
               aria-hidden="true" />
             </button>
           </div>
-          <button onClick={() => openModal(movie.tmdbId)} className="absolute top-4 right-4 h-10 w-10 p-0 rounded-full text-white bg-transparent z-50" aria-label={`View details for ${movie.title}`}>
+          <button onClick={() => openModal(movie.id)} className="absolute top-4 right-4 h-10 w-10 p-0 rounded-full text-white bg-transparent z-50" aria-label={`View details for ${movie.title}`}>
             <InfoIcon className="w-8 h-8 bg-secondary-500 rounded-full" aria-hidden="true" />
           </button>
         </div>
       </article>
-      <MovieModal movie={movie} isOpen={modalId === movie.tmdbId} closeModal={closeModal} />
+      <MovieModal movie={movie} isOpen={modalId === movie.id} closeModal={closeModal} />
     </>
   );
 };

--- a/src/hooks/useMovieFilters.js
+++ b/src/hooks/useMovieFilters.js
@@ -54,7 +54,7 @@ export const useMovieFilters = (movies) => {
       // Check rating range - show all if min is 1 and max is 10
       const matchesRating = (filters.rating.min == 1 && filters.rating.max == 10)
         ? true
-        : movie.rating >= filters.rating.min && movie.rating <= filters.rating.max;
+        : movie.ratings >= filters.rating.min && movie.ratings <= filters.rating.max;
       
       return matchesSearch && matchesGenre && matchesDecade && matchesRating;
     });

--- a/src/pages/Discover.jsx
+++ b/src/pages/Discover.jsx
@@ -44,7 +44,7 @@ const Discover = () => {
         <div className="card-wrapper relative w-full max-w-md mx-auto aspect-2/3">
           {visibileMovies.map((movie, index) => (
             <DiscoverCard 
-              key={movie.tmdbId} 
+              key={movie.id} 
               movie={movie} 
               onSwipe={handleSwipe} 
               isLoading={isLoading} 

--- a/src/pages/Discover.jsx
+++ b/src/pages/Discover.jsx
@@ -1,12 +1,12 @@
 import { useRef } from "react";
 import DiscoverCard from "@components/discover/DiscoverCard";
 import ScreenReaderAnnouncement from "@components/common/ScreenReaderAnnouncement";
-import { useUser } from "@providers/UserContext";
+import { useWatchlist } from "@/providers/WatchlistContext";
 import useMovieFeed from "@providers/MovieFeedContext.js";
 import { useAnnouncement } from "@hooks/useAnnouncement.js";
 
 const Discover = () => {
-	const { likeMovie, rejectMovie} = useUser();
+	const { likeMovie, rejectMovie} = useWatchlist();
   const { movieQueue, feedPosition, isLoading, moveToNext } = useMovieFeed();
   const { announcement, announce } = useAnnouncement();
   const topCardRef = useRef(null);

--- a/src/pages/WatchList.tsx
+++ b/src/pages/WatchList.tsx
@@ -1,13 +1,13 @@
 import { useState, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
-import { useUser } from "@providers/UserContext";
+import { useWatchlist } from "@/providers/WatchlistContext";
 import { useMovieFilters } from "@hooks/useMovieFilters";
 import WatchListGrid from "@components/watchlist/WatchListGrid";
 import WatchListFilter from "@components/watchlist/WatchListFilter";
 import WatchListPagination from "@components/watchlist/WatchListPagination";
 
 const WatchList = () => {
-  const { likedMovies, removeLikedMovie, isLoading } = useUser();
+  const { likedMovies, removeLikedMovie, isLoading } = useWatchlist();
   const {
     filters,
     filteredMovies,

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { AuthContext } from './AuthContext';
 import { useEffect, useState } from 'react';
-import authService from '@/services/auth';
+import authService from '@services/auth';
 import type { 
   User, 
   UserApiResponse, 

--- a/src/providers/MovieFeedProvider.tsx
+++ b/src/providers/MovieFeedProvider.tsx
@@ -1,5 +1,4 @@
 import { MovieFeedContext, type MovieFeedContextType } from "./MovieFeedContext";
-import { useUser } from "./UserContext";
 import useAuth from './AuthContext'
 import { useState, useEffect } from "react";
 import { useMinimumLoading } from "@hooks/useMinimumLoading";
@@ -12,7 +11,6 @@ const MovieFeedProvider = ({ children }: ProviderProps) => {
   const [feedPosition, setFeedPosition] = useState<number>(0);
   const [queryPage, setQueryPage] = useState<number>(1);
   const [error, setError] = useState<Error | null>(null);
-  const { likedMovies } = useUser();
   const { isAuthenticated } = useAuth();
   const { isLoading, startLoading, stopLoading } = useMinimumLoading(300);
 
@@ -24,14 +22,9 @@ const MovieFeedProvider = ({ children }: ProviderProps) => {
       if (fetchedMovies.results.length === 0) {
         throw new Error('No movies available at the moment. Please try again later.');
       }
-
-      // Filter out movies already in watchlist
-      const newMovies: Movie[] = fetchedMovies.results.filter(
-        (movie: Movie) => !likedMovies.some(liked => liked.id === movie.id) 
-      );
       
       const remainingMovies = movieQueue.slice(feedPosition + 1);
-      setMovieQueue([...remainingMovies, ...newMovies]);
+      setMovieQueue([...remainingMovies, ...fetchedMovies.results]);
       setFeedPosition(0);
 
     } catch (error) {

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -45,6 +45,8 @@ const UserProvider = ({ children }: ProviderProps) => {
 		
 		setLikedMovies((prev) => [...prev, newMovie]);
 		setRejectedMovies((prev) => prev.filter(movie => movie.id !== newMovie.id));
+
+    if(!isAuthenticated) return;
 		
 		try {
 			await watchlistService.addToWatchlist(newMovie);
@@ -67,6 +69,8 @@ const UserProvider = ({ children }: ProviderProps) => {
     const previousLikedMovies = likedMovies;
 
     setLikedMovies((prev) => prev.filter(movie => movie.id !== newMovie.id));
+
+    if(!isAuthenticated) return;
 
     try {
       watchlistService.removeFromWatchlist(newMovie.id);

--- a/src/providers/WatchlistContext.ts
+++ b/src/providers/WatchlistContext.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 import type { Movie } from '@/types/movie';
 
-export interface UserContextType {
+export interface WatchlistContextType {
   likedMovies: Movie[];
   rejectedMovies: Movie[];
   isLoading: boolean;
@@ -11,12 +11,12 @@ export interface UserContextType {
   removeLikedMovie: (movie: Movie) => void;
 }
 
-export const UserContext = createContext<UserContextType | undefined>(undefined);
+export const WatchlistContext = createContext<WatchlistContextType | undefined>(undefined);
 
-export const useUser = () => {
-  const context = useContext(UserContext);
+export const useWatchlist = () => {
+  const context = useContext(WatchlistContext);
   if (!context) {
-    throw new Error('useUser must be used within a UserProvider');
+    throw new Error('useWatchlist must be used within a WatchlistProvider');
   }
   return context;
 };

--- a/src/services/watchlist.ts
+++ b/src/services/watchlist.ts
@@ -72,6 +72,22 @@ class watchlistApi {
       throw new Error(`Watchlist API Error: ${errorText}`);
     }
   }
+
+  async addBulkToWatchlist(movies: Movie[]) {
+    const url = `${this.baseUrl}/bulk`;
+    const response = await this.fetchWithTimeout(url, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ movies: movies }),
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Watchlist API Error: ${errorText}`);
+    }
+  }
 }
 
 const watchlistService = new watchlistApi();

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -1,6 +1,5 @@
 export interface Movie {
-  id?: number;
-  tmdbId: number;
+  id: number;
   title: string;
   description: string;
   posterUrl: string;
@@ -8,6 +7,3 @@ export interface Movie {
   ratings: number;
   releaseDate: string;
 }
-
-export type Watchlist = Movie[];
-export type LikedMovies = Movie[]; // To be deprecated in future Watchlist implementation


### PR DESCRIPTION
### Summary
Implements automatic syncing of guest session watchlist items when users sign in, ensuring no liked movies are lost during the authentication flow.

### Changes
- **Data Models:** Updated movie data structure to support new watchlist bulk add requirements
- **API Integration:** Added bulk add endpoint to watchlist service
  - Connects to new POST /watchlist/bulk backend endpoint
  - Handles batch operations for improved performance  
- **Authentication Flow:** Implemented isAuthenticated logic to automatically migrate guest watchlist
  - Detects when user transitions from guest to authenticated state
  - Bulk adds all movies liked during guest session to user's account
- **Refactor:** Renamed UserProvider -> WatchlistProvider
  - Better reflects the provider's actual responsibilities
  - Improves code clarity and maintainability

### Technical Details
- Guest session watchlist items are stored in memory and synced on authentication
- Bulk add minimizes API calls compared to individual requests
- Provider rename includes all consuming components updated

### Related
- Pairs with backend PR: feat/watchlist-bulk-add