### PR TITLE
refactor: unify watchlist add methods to support bulk via single endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# ignore all files in the dist folder
+dist/
+
+# ignore all files in the node_modules folder
+node_modules/
+
+# ignore all files in the .env file
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev          # Start Vite dev server (default: http://localhost:5173)
+npm run build        # Production build
+npm run preview      # Preview production build
+npm run lint         # Run ESLint
+npm run test         # Run all tests once
+npm run test:watch   # Run tests in watch mode
+npm run test:coverage # Generate coverage report
+```
+
+To run a single test file:
+```bash
+npx vitest run src/services/AuthService.test.js
+```
+
+The app expects a backend at `http://localhost:3000/api/` by default (configurable via `VITE_BACKEND_URL`).
+
+## Architecture
+
+### Overview
+React 19 SPA for movie discovery — users swipe to like/reject movies, build a watchlist, and chat with an AI assistant (Movio). Built with Vite, TypeScript (mixed TS/JSX codebase), TailwindCSS v4, and React Router v7.
+
+### State Management — Three Context Providers
+All providers are nested in `App.jsx` and wrap the entire app:
+
+1. **`AuthProvider`** (`src/providers/AuthProvider.tsx`) — auth status, current user, login/register/logout. Auto-checks session on mount via `auth/check`.
+2. **`WatchlistProvider`** (`src/providers/WatchlistProvider.tsx`) — `likedMovies`, `rejectedMovies`, like/reject/remove actions. On login, syncs guest watchlist to server via `addBulkToWatchlist`.
+3. **`MovieFeedProvider`** (`src/providers/MovieFeedProvider.tsx`) — the queue of movies for swiping, feed position, and pagination.
+
+### Services Layer
+All API calls go through class-based services in `src/services/`. Each service uses a `fetchWithTimeout()` helper (AbortController-based) with `credentials: 'include'` for cookie auth. Services throw descriptive errors using server-provided messages when available.
+
+- `auth.ts` — register, login, logout, check session
+- `movies.ts` — TMDB-proxied movie data (recommendations, popular, genres, details)
+- `watchlist.ts` — CRUD for user watchlist + bulk add for guest sync
+- `agent.ts` — OpenAI chat proxy (30s timeout)
+- `recommendations.ts` — movie recommendations endpoint
+
+### Authentication
+JWT + HttpOnly cookies. The backend sets the cookie; the frontend just sends `credentials: 'include'` with every request. Session persists across page refreshes via `GET /auth/check` on app load.
+
+### Path Aliases
+Configured in both `vite.config.js` and `tsconfig.json`. Use these instead of relative paths:
+`@/`, `@components/`, `@services/`, `@hooks/`, `@providers/`, `@icons`, `@pages/`, `@helpers/`, `@types/`
+
+### Testing
+- Vitest + React Testing Library + JSDOM
+- `src/tests/setupTests.js` — imports jest-dom matchers, mocks `global.fetch` with `vi.fn()`
+- Unit tests are co-located with source files (`*.test.js` / `*.test.jsx`)
+- Integration tests live in `src/tests/integrations/`
+
+### Deployment
+CI runs on GitHub Actions: lint → test (3 retries) → build. Production deploys to AWS S3 + CloudFront invalidation. Vercel config (`vercel.json`) rewrites API calls to the Railway-hosted backend.

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -474,7 +473,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -518,7 +516,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1714,7 +1711,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2037,6 +2033,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2057,6 +2054,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2067,6 +2065,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2080,6 +2079,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2094,7 +2094,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -2166,7 +2167,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2250,7 +2252,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2261,7 +2262,6 @@
       "integrity": "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2272,7 +2272,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2457,7 +2456,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2620,7 +2618,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -2906,7 +2903,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -3034,7 +3032,6 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3614,7 +3611,6 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -4005,6 +4001,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4397,7 +4394,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4510,7 +4506,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4520,7 +4515,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4614,7 +4608,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
       "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4977,7 +4970,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5038,7 +5030,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5128,7 +5119,6 @@
       "integrity": "sha512-4H+J28MI5oeYgGg3h5BFSkQ1g/2GKK1IR8oorH3a6EQQbb7CwjbnyBjH4PGxw9/6vpwAPNzaeUMp4Js4WJmdXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.5",
         "@vitest/mocker": "4.0.5",
@@ -5310,7 +5300,6 @@
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/providers/MovieFeedProvider.tsx
+++ b/src/providers/MovieFeedProvider.tsx
@@ -35,7 +35,7 @@ const MovieFeedProvider = ({ children }: ProviderProps) => {
       setError(err);
     } finally {
       stopLoading();
-    }
+    } 
   }
 
   function moveToNext(): void {

--- a/src/providers/WatchlistProvider.tsx
+++ b/src/providers/WatchlistProvider.tsx
@@ -20,7 +20,7 @@ const WatchlistProvider = ({ children }: ProviderProps) => {
       // Sync guest watchlist with user watchlist
       const guestWatchlist = likedMovies;
       if (guestWatchlist.length > 0) {
-        await watchlistService.addBulkToWatchlist(guestWatchlist);
+        await watchlistService.addToWatchlist(guestWatchlist);
       }
       // fetch the complete watchlist from the backend 
       const rawData = await watchlistService.getWatchlist();

--- a/src/services/watchlist.ts
+++ b/src/services/watchlist.ts
@@ -30,8 +30,8 @@ class watchlistApi {
     }
   }
 
-  // adds a movie to the user's watchlist
-  async addToWatchlist(movie: Movie) {
+  // adds one or more movies to the user's watchlist
+  async addToWatchlist(movie: Movie | Movie[]) {
     const url = `${this.baseUrl}`;
     const response = await this.fetchWithTimeout(url, {
       method: 'POST',
@@ -39,7 +39,7 @@ class watchlistApi {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ movie }),
+      body: JSON.stringify({ movies: Array.isArray(movie) ? movie : [movie] }),
     });
 
     if (!response.ok) {
@@ -66,22 +66,6 @@ class watchlistApi {
     const response = await this.fetchWithTimeout(url, {
       method: 'DELETE',
       credentials: 'include',
-    });
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Watchlist API Error: ${errorText}`);
-    }
-  }
-
-  async addBulkToWatchlist(movies: Movie[]) {
-    const url = `${this.baseUrl}/bulk`;
-    const response = await this.fetchWithTimeout(url, {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ movies: movies }),
     });
     if (!response.ok) {
       const errorText = await response.text();


### PR DESCRIPTION
## Summary
Refactors frontend watchlist service to consolidate `addBulkToWatchlist` into `addToWatchlist`, aligning with backend changes where `POST /watchlist` now accepts both single and array payloads for bulk additions.

## Changes
- Unified watchlist add methods
  - Removed `addBulkToWatchlist` from watchlist service
  - Updated `addToWatchlist` to support:
    - single movie payload
    - array of movies for bulk addition
- Updated API integration
  - Adjusted request handling to send array payloads when multiple items are provided
  - Ensured compatibility with updated backend endpoint
- Refactored call sites
  - Replaced usages of `addBulkToWatchlist` with `addToWatchlist`
  - Simplified client-side logic for bulk vs single add flows

## Testing
- Verified:
  - Adding a single movie to watchlist
  - Adding multiple movies via array payload
  - Proper handling of API responses and error states
- Updated/validated any existing frontend tests covering watchlist interactions

## Design Notes / Rationale
- Aligns frontend API layer with backend contract changes
- Reduces redundancy by removing separate bulk method
- Simplifies service interface and usage patterns across the app
- Improves maintainability by consolidating logic into a single entry point