### PR TITLE
feat: auth gate, guest sessions, and account management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
 import AuthProvider from '@providers/AuthProvider.jsx';
+import GuestBannerProvider from '@providers/GuestBannerProvider';
 import useAuth from '@providers/AuthContext';
 import MainLayout from '@layouts/MainLayout.jsx';
 import DiscoverLayout from '@layouts/DiscoverLayout.jsx';
@@ -52,7 +53,9 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <AppContent />
+        <GuestBannerProvider>
+          <AppContent />
+        </GuestBannerProvider>
       </AuthProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,15 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
 import AuthProvider from '@providers/AuthProvider.jsx';
+import useAuth from '@providers/AuthContext';
 import MainLayout from '@layouts/MainLayout.jsx';
 import DiscoverLayout from '@layouts/DiscoverLayout.jsx';
 import NotFound from '@pages/NotFound.jsx';
 import WatchList from '@pages/WatchList';
 import Discover from '@pages/Discover.jsx';
+import Account from '@pages/Account';
 import AiChat from '@components/chat/AiChat.jsx';
+import AuthGate from '@components/auth/AuthGate';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,18 +28,31 @@ const router = createBrowserRouter(
       </Route>
       <Route element={<MainLayout />}>
         <Route path="watchlist" element={<WatchList />} />
+        <Route path="account" element={<Account />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </>
   )
 );
 
+function AppContent() {
+  const { user, isInitialLoading } = useAuth();
+  const showAuthGate = !isInitialLoading && !user;
+
+  return (
+    <>
+      <RouterProvider router={router} />
+      <AiChat />
+      {showAuthGate && <AuthGate />}
+    </>
+  );
+}
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <RouterProvider router={router} />
-        <AiChat />
+        <AppContent />
       </AuthProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/components/auth/AccountSettingsForm.tsx
+++ b/src/components/auth/AccountSettingsForm.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import useAuth from '@providers/AuthContext';
+import type { UpdateAccountData } from '@/types/auth';
+
+const AccountSettingsForm = () => {
+  const { user, updateAccount, isLoading, error } = useAuth();
+  const [formData, setFormData] = useState({
+    firstName: user?.firstName ?? '',
+    lastName: user?.lastName ?? '',
+    email: user?.email ?? '',
+    password: '',
+  });
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSuccessMsg(null);
+    const payload: UpdateAccountData = {};
+    if (formData.firstName) payload.firstName = formData.firstName;
+    if (formData.lastName)  payload.lastName  = formData.lastName;
+    if (formData.email)     payload.email     = formData.email;
+    if (formData.password)  payload.password  = formData.password;
+    await updateAccount(payload);
+    setSuccessMsg('Account updated successfully.');
+    setFormData(p => ({ ...p, password: '' }));
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {error && <p className="text-red-500">{error.message}</p>}
+      {successMsg && <p className="text-green-500">{successMsg}</p>}
+      <label htmlFor="account-first">First Name</label>
+      <input
+        id="account-first"
+        type="text"
+        value={formData.firstName}
+        onChange={e => setFormData(p => ({ ...p, firstName: e.target.value }))}
+        className="border-0 border-b-2 border-primary-subtle rounded-none"
+      />
+      <label htmlFor="account-last">Last Name</label>
+      <input
+        id="account-last"
+        type="text"
+        value={formData.lastName}
+        onChange={e => setFormData(p => ({ ...p, lastName: e.target.value }))}
+        className="border-0 border-b-2 border-primary-subtle rounded-none"
+      />
+      <label htmlFor="account-email">Email</label>
+      <input
+        id="account-email"
+        type="email"
+        value={formData.email}
+        onChange={e => setFormData(p => ({ ...p, email: e.target.value }))}
+        className="border-0 border-b-2 border-primary-subtle rounded-none"
+      />
+      <label htmlFor="account-password">
+        New Password{' '}
+        <span className="type-label-sm text-text-muted">(leave blank to keep current)</span>
+      </label>
+      <input
+        id="account-password"
+        type="password"
+        placeholder="New password (optional)"
+        value={formData.password}
+        onChange={e => setFormData(p => ({ ...p, password: e.target.value }))}
+        className="border-0 border-b-2 border-primary-subtle rounded-none"
+      />
+      <button type="submit" disabled={isLoading} className="mt-4">
+        Save Changes
+      </button>
+    </form>
+  );
+};
+
+export default AccountSettingsForm;

--- a/src/components/auth/AuthGate.tsx
+++ b/src/components/auth/AuthGate.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import useAuth from '@providers/AuthContext';
+import LoginForm from './LoginForm';
+import SignUpForm from './SignUpForm';
+
+type Tab = 'options' | 'login' | 'register';
+
+const AuthGate = () => {
+  const { createGuestSession, isLoading } = useAuth();
+  const [tab, setTab] = useState<Tab>('options');
+
+  return (
+    <div
+      className="fixed top-0 left-0 w-full h-full flex items-center justify-center z-50 bg-black/60 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="auth-gate-title"
+    >
+      <div className="bg-surface border-2 rounded-2xl shadow-lg w-full max-w-md mx-4 p-8 flex flex-col gap-4">
+
+        {tab === 'options' && (
+          <>
+            <div>
+              <h2 id="auth-gate-title" className="type-heading-md">Welcome to MovieSwiper</h2>
+              <p className="type-prose-md mt-2">Sign in, create an account, or continue as a guest.</p>
+            </div>
+            <button
+              className="border-2 bg-transparent border-primary-muted text-primary-muted"
+              onClick={createGuestSession}
+              disabled={isLoading}
+            >
+              Continue as Guest
+            </button>
+            <div className="flex items-center gap-3">
+              <hr className="flex-1 border-border-strong" />
+              <span className="type-label-sm text-text-muted">or continue with account</span>
+              <hr className="flex-1 border-border-strong" />
+            </div>
+            <button onClick={() => setTab('register')}>
+              Create Account
+            </button>
+            <button
+              className="border-2 bg-transparent border-primary-muted text-primary-muted"
+              onClick={() => setTab('login')}
+            >
+              Login
+            </button>
+          </>
+        )}
+
+        {tab === 'login' && (
+          <>
+            <button
+              className="self-start p-0 bg-transparent h-fit w-fit text-text-muted type-label-sm"
+              onClick={() => setTab('options')}
+              type="button"
+            >
+              ← Back
+            </button>
+            <LoginForm />
+          </>
+        )}
+
+        {tab === 'register' && (
+          <>
+            <button
+              className="self-start p-0 bg-transparent h-fit w-fit text-text-muted type-label-sm"
+              onClick={() => setTab('options')}
+              type="button"
+            >
+              ← Back
+            </button>
+            <SignUpForm />
+          </>
+        )}
+
+      </div>
+    </div>
+  );
+};
+
+export default AuthGate;

--- a/src/components/auth/GuestBanner.tsx
+++ b/src/components/auth/GuestBanner.tsx
@@ -10,33 +10,57 @@ const GuestBanner = () => {
 
   if (!isGuest || dismissed) return null;
 
-  const handleDismiss = () => {
-    setAnimating(true);
-  };
+  const handleDismiss = () => setAnimating(true);
+
+  const dismissBtn = (
+    <button
+      onClick={handleDismiss}
+      className="bg-transparent border-0 p-1 h-fit not-italic text-text-muted hover:text-text-default leading-none"
+      aria-label="Dismiss"
+    >
+      ✕
+    </button>
+  );
 
   return (
     <div
-      className={`w-full bg-primary/20 border-b border-primary-muted flex items-center justify-center gap-4 relative overflow-hidden transition-all duration-300 ease-in-out ${
-        animating ? 'max-h-0 opacity-0 py-0' : 'max-h-24 opacity-100 py-2'
-      } px-4`}
+      className={`w-full bg-primary/20 border-b border-primary-muted overflow-hidden transition-all duration-300 ease-in-out px-4 ${
+        animating ? 'max-h-0 opacity-0 py-0' : 'max-h-40 opacity-100 py-2'
+      }`}
       onTransitionEnd={() => animating && dismiss()}
     >
-      <p className="type-label-sm text-text-default text-center">
-        You&apos;re browsing as a guest. Create an account to save your watchlist permanently.
-      </p>
-      <Link
-        to="/account"
-        className="type-label-sm text-primary-muted underline underline-offset-2 whitespace-nowrap"
-      >
-        Create Account →
-      </Link>
-      <button
-        onClick={handleDismiss}
-        className="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-0 p-1 h-fit not-italic text-text-muted hover:text-text-default leading-none"
-        aria-label="Dismiss"
-      >
-        ✕
-      </button>
+      {/* Mobile: stacked left, close top-right */}
+      <div className="flex md:hidden relative pr-8">
+        <div className="flex flex-col items-start gap-1">
+          <p className="type-label-sm text-text-default">
+            Create an account to save your watchlist permanently.
+          </p>
+          <Link
+            to="/account"
+            className="type-label-sm text-primary-muted underline underline-offset-2"
+          >
+            Create Account →
+          </Link>
+        </div>
+        <div className="absolute top-0 right-0">{dismissBtn}</div>
+      </div>
+
+      {/* Desktop: centered 3-col grid */}
+      <div className="hidden md:grid grid-cols-[1fr_auto_1fr] items-center">
+        <div />
+        <div className="flex items-center gap-3">
+          <p className="type-label-sm text-text-default">
+            Create an account to save your watchlist permanently.
+          </p>
+          <Link
+            to="/account"
+            className="type-label-sm text-primary-muted underline underline-offset-2 whitespace-nowrap"
+          >
+            Create Account →
+          </Link>
+        </div>
+        <div className="flex justify-end">{dismissBtn}</div>
+      </div>
     </div>
   );
 };

--- a/src/components/auth/GuestBanner.tsx
+++ b/src/components/auth/GuestBanner.tsx
@@ -1,13 +1,27 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import useAuth from '@providers/AuthContext';
+import { useGuestBanner } from '@providers/GuestBannerProvider';
 
 const GuestBanner = () => {
   const { isGuest } = useAuth();
-  if (!isGuest) return null;
+  const { dismissed, dismiss } = useGuestBanner();
+  const [animating, setAnimating] = useState(false);
+
+  if (!isGuest || dismissed) return null;
+
+  const handleDismiss = () => {
+    setAnimating(true);
+  };
 
   return (
-    <div className="w-full bg-primary/20 border-b border-primary-muted px-4 py-2 flex items-center justify-between gap-4">
-      <p className="type-label-sm text-text-default">
+    <div
+      className={`w-full bg-primary/20 border-b border-primary-muted flex items-center justify-center gap-4 relative overflow-hidden transition-all duration-300 ease-in-out ${
+        animating ? 'max-h-0 opacity-0 py-0' : 'max-h-24 opacity-100 py-2'
+      } px-4`}
+      onTransitionEnd={() => animating && dismiss()}
+    >
+      <p className="type-label-sm text-text-default text-center">
         You&apos;re browsing as a guest. Create an account to save your watchlist permanently.
       </p>
       <Link
@@ -16,6 +30,13 @@ const GuestBanner = () => {
       >
         Create Account →
       </Link>
+      <button
+        onClick={handleDismiss}
+        className="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-0 p-1 h-fit not-italic text-text-muted hover:text-text-default leading-none"
+        aria-label="Dismiss"
+      >
+        ✕
+      </button>
     </div>
   );
 };

--- a/src/components/auth/GuestBanner.tsx
+++ b/src/components/auth/GuestBanner.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+import useAuth from '@providers/AuthContext';
+
+const GuestBanner = () => {
+  const { isGuest } = useAuth();
+  if (!isGuest) return null;
+
+  return (
+    <div className="w-full bg-primary/20 border-b border-primary-muted px-4 py-2 flex items-center justify-between gap-4">
+      <p className="type-label-sm text-text-default">
+        You&apos;re browsing as a guest. Create an account to save your watchlist permanently.
+      </p>
+      <Link
+        to="/account"
+        className="type-label-sm text-primary-muted underline underline-offset-2 whitespace-nowrap"
+      >
+        Create Account →
+      </Link>
+    </div>
+  );
+};
+
+export default GuestBanner;

--- a/src/components/auth/PromoteAccountForm.tsx
+++ b/src/components/auth/PromoteAccountForm.tsx
@@ -30,10 +30,6 @@ const PromoteAccountForm = ({ onSuccess }: PromoteAccountFormProps) => {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      <div>
-        <h2 className="type-heading-md">Create Your Account</h2>
-        <p className="type-prose-md mt-2">Set up your account to save your watchlist and preferences permanently.</p>
-      </div>
       {validationError && <p className="text-red-500">{validationError}</p>}
       {error && <p className="text-red-500">{error.message}</p>}
       <label htmlFor="promote-email">Email</label>

--- a/src/components/auth/PromoteAccountForm.tsx
+++ b/src/components/auth/PromoteAccountForm.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { SignInIcon } from '@icons';
+import useAuth from '@providers/AuthContext';
+import type { PromoteAccountData } from '@/types/auth';
+
+interface PromoteAccountFormProps {
+  onSuccess?: () => void;
+}
+
+const PromoteAccountForm = ({ onSuccess }: PromoteAccountFormProps) => {
+  const { promoteAccount, isLoading, error } = useAuth();
+  const [formData, setFormData] = useState<PromoteAccountData>({
+    email: '',
+    firstName: '',
+    lastName: '',
+    password: '',
+  });
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.email || !formData.firstName || !formData.lastName || !formData.password) {
+      setValidationError('All fields are required.');
+      return;
+    }
+    setValidationError(null);
+    await promoteAccount(formData);
+    onSuccess?.();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div>
+        <h2 className="type-heading-md">Create Your Account</h2>
+        <p className="type-prose-md mt-2">Set up your account to save your watchlist and preferences permanently.</p>
+      </div>
+      {validationError && <p className="text-red-500">{validationError}</p>}
+      {error && <p className="text-red-500">{error.message}</p>}
+      <label htmlFor="promote-email">Email</label>
+      <input
+        id="promote-email"
+        type="email"
+        placeholder="Enter your email"
+        value={formData.email}
+        onChange={e => setFormData(p => ({ ...p, email: e.target.value }))}
+        className="border-0 border-b-2 border-primary-subtle rounded-none"
+      />
+      <label htmlFor="promote-first">First Name</label>
+      <input
+        id="promote-first"
+        type="text"
+        placeholder="Enter your first name"
+        value={formData.firstName}
+        onChange={e => setFormData(p => ({ ...p, firstName: e.target.value }))}
+        className="border-0 border-b-2 border-primary-subtle rounded-none"
+      />
+      <label htmlFor="promote-last">Last Name</label>
+      <input
+        id="promote-last"
+        type="text"
+        placeholder="Enter your last name"
+        value={formData.lastName}
+        onChange={e => setFormData(p => ({ ...p, lastName: e.target.value }))}
+        className="border-0 border-b-2 border-primary-subtle rounded-none"
+      />
+      <label htmlFor="promote-password">Password</label>
+      <input
+        id="promote-password"
+        type="password"
+        placeholder="Create a password"
+        value={formData.password}
+        onChange={e => setFormData(p => ({ ...p, password: e.target.value }))}
+        className="border-0 border-b-2 border-primary-subtle rounded-none"
+      />
+      <button type="submit" disabled={isLoading} className="mt-4">
+        Create Account <SignInIcon className="inline-block ml-2" height={20} width={20} />
+      </button>
+    </form>
+  );
+};
+
+export default PromoteAccountForm;

--- a/src/components/auth/UserMenu.jsx
+++ b/src/components/auth/UserMenu.jsx
@@ -6,7 +6,7 @@ import useAuth from "@providers/AuthContext";
 
 const UserMenu = () => {
   const { popovers, togglePopover } = usePopover();
-  const { user, logout } = useAuth();
+  const { user, isGuest, logout } = useAuth();
 
   const handleLogout = async () => {
     try {
@@ -24,7 +24,7 @@ const UserMenu = () => {
 
     {popovers["user-menu"] && (
     <div className="popover flex flex-col gap-4 absolute right-0 top-full mt-6 w-48 bg-surface-raised p-4 rounded-2xl shadow-lg z-50">
-      <p className="type-label-md text-white">Hello, {user.firstName}!</p>
+      <p className="type-label-md text-white">Hello, {isGuest ? 'Guest' : user.firstName}!</p>
       <Link to="/account" className="type-label-sm block w-full text-left text-text-default">Account</Link>
       <button className="not-italic font-bold block w-full" onClick={handleLogout}>
       Sign Out

--- a/src/components/auth/UserMenu.jsx
+++ b/src/components/auth/UserMenu.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { usePopover } from '@hooks/usePopover';
 import { UserIcon, SignOutIcon } from "@icons";
 import useAuth from "@providers/AuthContext";
@@ -24,12 +25,8 @@ const UserMenu = () => {
     {popovers["user-menu"] && (
     <div className="popover flex flex-col gap-4 absolute right-0 top-full mt-6 w-48 bg-surface-raised p-4 rounded-2xl shadow-lg z-50">
       <p className="type-label-md text-white">Hello, {user.firstName}!</p>
-      <ul className="flex flex-col gap-2">
-      <li className="type-label-sm block w-full text-left text-text-default">Profile</li>
-      <li className="type-label-sm block w-full text-left text-text-default">Settings</li>
-      <li className="type-label-sm block w-full text-left text-text-default">Account</li>
-      </ul>
-      <button className="type-label-sm block w-full text-text-default" onClick={handleLogout}>
+      <Link to="/account" className="type-label-sm block w-full text-left text-text-default">Account</Link>
+      <button className="not-italic font-bold block w-full" onClick={handleLogout}>
       Sign Out
       <SignOutIcon className="inline-block ml-2" height={16} width={16} />
       </button>

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -8,7 +8,7 @@ import { usePopover } from "@hooks/usePopover";
 import { SignOutIcon } from "@icons";
 
 const Header = () => {
-    const { isAuthenticated, logout, user } = useAuth();
+    const { isAuthenticated, isGuest, logout, user } = useAuth();
     const { popovers, togglePopover } = usePopover();
 
     const handleLogout = async () => {
@@ -78,22 +78,15 @@ const Header = () => {
                             {isAuthenticated && (
                                 <>
                                     <hr className="border-1 w-full border-border-strong" />
-                                    <NavLink to="/profile" className="nav-link text-white">
-                                        Profile
-                                    </NavLink>
-                                    <NavLink to="/settings" className="nav-link text-white">
-                                        Settings
-                                    </NavLink>
                                     <NavLink to="/account" className="nav-link text-white">
                                         Account
                                     </NavLink>
-
                                 </>
                             )}
                         </nav>
                         {isAuthenticated ? (
                             <>
-                                <p className="type-label-md self-center">Logged in as {user.firstName}, not you?</p>
+                                <p className="type-label-md self-center">Logged in as {isGuest ? 'Guest' : user.firstName}, not you?</p>
                                 <button className="type-label-sm block w-full text-text-default" onClick={handleLogout}>
                                     Sign Out
                                     <SignOutIcon className="inline-block ml-2" height={16} width={16} />

--- a/src/layouts/DiscoverLayout.jsx
+++ b/src/layouts/DiscoverLayout.jsx
@@ -1,11 +1,13 @@
 import Header from "@components/common/Header";
 import Footer from "@components/common/Footer";
+import GuestBanner from "@components/auth/GuestBanner";
 import { Outlet } from "react-router-dom";
 
 const DiscoverLayout = () => {
   return (
     <div className="flex flex-col h-dvh overflow-hidden">
       <Header />
+      <GuestBanner />
       <Outlet />
       <Footer />
     </div>

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -1,11 +1,13 @@
 import Header from "@components/common/Header";
 import Footer from "@components/common/Footer";
+import GuestBanner from "@components/auth/GuestBanner";
 import { Outlet } from "react-router-dom";
 
 const MainLayout = () => {
   return (
     <>
       <Header />
+      <GuestBanner />
       <Outlet />
       <Footer />
     </>

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,0 +1,50 @@
+import useAuth from '@providers/AuthContext';
+import PromoteAccountForm from '@components/auth/PromoteAccountForm';
+import AccountSettingsForm from '@components/auth/AccountSettingsForm';
+import { SignOutIcon } from '@icons';
+
+const Account = () => {
+  const { isGuest, user, logout } = useAuth();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (e) {
+      console.error('Logout failed:', e);
+    }
+  };
+
+  return (
+    <main className="flex-1 py-12 px-4">
+      <div className="w-full max-w-lg mx-auto flex flex-col gap-8">
+        <div>
+          <h1 className="type-display-xs">
+            {isGuest ? 'Create Your Account' : 'Account Settings'}
+          </h1>
+          {isGuest && (
+            <p className="type-prose-md mt-2">
+              You&apos;re currently a guest. Create a permanent account to keep your watchlist and preferences.
+            </p>
+          )}
+          {!isGuest && user && (
+            <div className="flex items-center gap-3 mt-2">
+              <p className="type-prose-md">
+                Signed in as {user.firstName} {user.lastName} ({user.email})
+              </p>
+              <button
+                onClick={handleLogout}
+                className="bg-transparent border-0 p-0 h-fit not-italic font-normal text-text-muted hover:text-text-default flex items-center gap-1 type-label-sm"
+              >
+                <SignOutIcon height={14} width={14} />
+                Log out
+              </button>
+            </div>
+          )}
+        </div>
+        {isGuest ? <PromoteAccountForm /> : <AccountSettingsForm />}
+      </div>
+    </main>
+  );
+};
+
+export default Account;

--- a/src/providers/AuthContext.ts
+++ b/src/providers/AuthContext.ts
@@ -1,14 +1,19 @@
 import { createContext, useContext } from 'react';
-import type { User, LoginCredentials, RegisterData } from '@/types/auth';
+import type { User, LoginCredentials, RegisterData, PromoteAccountData, UpdateAccountData } from '@/types/auth';
 
 export interface AuthContextType {
   isAuthenticated: boolean;
+  isGuest: boolean;
+  isInitialLoading: boolean;
   user: User | null;
   isLoading: boolean;
   error: Error | null;
   login: (credentials: LoginCredentials) => Promise<void>;
   logout: () => Promise<void>;
   register: (registerData: RegisterData) => Promise<void>;
+  createGuestSession: () => Promise<void>;
+  promoteAccount: (data: PromoteAccountData) => Promise<void>;
+  updateAccount: (data: UpdateAccountData) => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,10 +1,18 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { AuthContext } from './AuthContext';
-import { getCurrentUser, login, logout, register } from '@services/auth';
+import {
+  getCurrentUser,
+  login,
+  logout,
+  register,
+  createGuestSession as createGuestSessionService,
+  promoteAccount as promoteAccountService,
+  updateAccount as updateAccountService,
+} from '@services/auth';
 import { addToWatchlist } from '@services/authWatchlist';
 import { getWatchlist as getGuestWatchlist, clearWatchlist as clearGuestWatchlist } from '@services/guestWatchlist';
 import { queryKeys } from '@/queries/keys';
-import type { LoginCredentials, RegisterData } from '@/types/auth';
+import type { LoginCredentials, RegisterData, PromoteAccountData, UpdateAccountData } from '@/types/auth';
 import type { ProviderProps } from '@/types/provider';
 
 async function syncGuestWatchlist(): Promise<void> {
@@ -18,7 +26,7 @@ async function syncGuestWatchlist(): Promise<void> {
 const AuthProvider = ({ children }: ProviderProps) => {
   const queryClient = useQueryClient();
 
-  const { data: user, isError, isPending: isCheckingAuth } = useQuery({
+  const { data: user, isError, isPending: isInitialLoading } = useQuery({
     queryKey: queryKeys.auth.currentUser(),
     queryFn: getCurrentUser,
     staleTime: Infinity,
@@ -51,15 +59,47 @@ const AuthProvider = ({ children }: ProviderProps) => {
     },
   });
 
+  const createGuestMutation = useMutation({
+    mutationFn: createGuestSessionService,
+    onSuccess: async (data) => {
+      queryClient.setQueryData(queryKeys.auth.currentUser(), data);
+      await syncGuestWatchlist();
+      queryClient.invalidateQueries({ queryKey: queryKeys.watchlist.list() });
+    },
+  });
+
+  const promoteMutation = useMutation({
+    mutationFn: (data: PromoteAccountData) => promoteAccountService(data),
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.auth.currentUser(), data);
+    },
+  });
+
+  const updateAccountMutation = useMutation({
+    mutationFn: (data: UpdateAccountData) => updateAccountService(data),
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.auth.currentUser(), data);
+    },
+  });
+
   const isAuthenticated = !isError && !!user?.id;
+  const isGuest = isAuthenticated && (user?.isGuest === true);
   const isLoading =
-    isCheckingAuth ||
+    isInitialLoading ||
     loginMutation.isPending ||
     logoutMutation.isPending ||
-    registerMutation.isPending;
-  const error = (loginMutation.error ||
+    registerMutation.isPending ||
+    createGuestMutation.isPending ||
+    promoteMutation.isPending ||
+    updateAccountMutation.isPending;
+  const error = (
+    loginMutation.error ||
     logoutMutation.error ||
-    registerMutation.error) as Error | null;
+    registerMutation.error ||
+    createGuestMutation.error ||
+    promoteMutation.error ||
+    updateAccountMutation.error
+  ) as Error | null;
 
   async function handleLogin(credentials: LoginCredentials): Promise<void> {
     await loginMutation.mutateAsync(credentials);
@@ -73,16 +113,33 @@ const AuthProvider = ({ children }: ProviderProps) => {
     await registerMutation.mutateAsync(registerData);
   }
 
+  async function handleCreateGuestSession(): Promise<void> {
+    await createGuestMutation.mutateAsync();
+  }
+
+  async function handlePromoteAccount(data: PromoteAccountData): Promise<void> {
+    await promoteMutation.mutateAsync(data);
+  }
+
+  async function handleUpdateAccount(data: UpdateAccountData): Promise<void> {
+    await updateAccountMutation.mutateAsync(data);
+  }
+
   return (
     <AuthContext.Provider
       value={{
         isAuthenticated,
+        isGuest,
+        isInitialLoading,
         user: user ?? null,
         isLoading,
         error,
         login: handleLogin,
         logout: handleLogout,
         register: handleRegister,
+        createGuestSession: handleCreateGuestSession,
+        promoteAccount: handlePromoteAccount,
+        updateAccount: handleUpdateAccount,
       }}
     >
       {children}

--- a/src/providers/GuestBannerProvider.tsx
+++ b/src/providers/GuestBannerProvider.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState } from 'react';
+import type { ProviderProps } from '@/types/provider';
+
+interface GuestBannerContextType {
+  dismissed: boolean;
+  dismiss: () => void;
+}
+
+const GuestBannerContext = createContext<GuestBannerContextType | undefined>(undefined);
+
+export const useGuestBanner = () => {
+  const ctx = useContext(GuestBannerContext);
+  if (!ctx) throw new Error('useGuestBanner must be used within GuestBannerProvider');
+  return ctx;
+};
+
+const GuestBannerProvider = ({ children }: ProviderProps) => {
+  const [dismissed, setDismissed] = useState(false);
+
+  return (
+    <GuestBannerContext.Provider value={{ dismissed, dismiss: () => setDismissed(true) }}>
+      {children}
+    </GuestBannerContext.Provider>
+  );
+};
+
+export default GuestBannerProvider;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,6 +1,6 @@
 import apiClient from './apiClient';
 import { storeTokens, clearTokens, getRefreshToken } from './tokenStorage';
-import type { User, AuthResponse, LoginCredentials, RegisterData } from '../types/auth';
+import type { User, AuthResponse, LoginCredentials, RegisterData, PromoteAccountData, UpdateAccountData } from '../types/auth';
 
 const TIMEOUT = 10000;
 
@@ -27,4 +27,20 @@ export async function logout() {
 export async function getCurrentUser(): Promise<User> {
   const response = await apiClient.get<User>('/auth/check', { timeout: TIMEOUT });
   return response.data;
+}
+
+export async function createGuestSession(): Promise<User> {
+  const response = await apiClient.post<AuthResponse>('/auth/guest', {}, { timeout: TIMEOUT });
+  storeTokens(response.data.accessToken, response.data.refreshToken);
+  return response.data.user;
+}
+
+export async function promoteAccount(data: PromoteAccountData): Promise<User> {
+  const response = await apiClient.patch<{ user: User }>('/auth/promote', data, { timeout: TIMEOUT });
+  return response.data.user;
+}
+
+export async function updateAccount(data: UpdateAccountData): Promise<User> {
+  const response = await apiClient.patch<{ user: User }>('/auth/account', data, { timeout: TIMEOUT });
+  return response.data.user;
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -3,6 +3,21 @@ export interface User {
   firstName: string;
   lastName: string;
   email: string;
+  isGuest?: boolean;
+}
+
+export interface PromoteAccountData {
+  email: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+}
+
+export interface UpdateAccountData {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  password?: string;
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
## What

Shifts guest account responsibility to the backend and adds a full auth gate experience — users are prompted to log in, register, or continue as a guest on every cold load. Guest users get real backend sessions, can be identified across the app, and can upgrade to a full account at any time.

## Changes

- auth gate: blocking modal on cold load with Sign In / Create Account / Continue as Guest; auto-dismisses when any session is established
- guest sessions: backend-issued guest tokens via \`POST /auth/guest\` replacing localStorage-only state; old localStorage items migrated on first guest session
- guest identity: header and user menu show \"Guest\" in place of first name for guest sessions
- guest banner: dismissable banner across all layouts for guest users with slide-up animation; dismissed state held globally via \`GuestBannerProvider\`
- account page: \`/account\` route with promote form for guests and settings form for full users; inline logout beside signed-in-as text
- promote flow: \`PromoteAccountForm\` converts guest → full account via \`PATCH /auth/promote\`
- account settings: \`AccountSettingsForm\` for updating name, email, and optional password change
- auth context: \`isGuest\`, \`isInitialLoading\`, \`createGuestSession\`, \`promoteAccount\`, \`updateAccount\` added to provider and context interface
- nav cleanup: removed dead Profile/Settings links from desktop user menu and mobile header; Account link wired up

## Testing

- [ ] Tests pass locally
- [ ] Cold load with no tokens shows auth gate
- [ ] Continue as Guest dismisses gate, shows guest banner
- [ ] Guest banner slides up on dismiss and stays dismissed across routes
- [ ] /account shows promote form for guests, settings form for full users
- [ ] Promoting guest account converts session and hides banner
- [ ] Login/register via auth gate dismisses gate and shows correct user name
- [ ] User menu and mobile header show "Guest" for guest sessions