### PR TITLE
fix: watchlist data not loading on page load

### DIFF
--- a/src/queries/useWatchlist.ts
+++ b/src/queries/useWatchlist.ts
@@ -85,18 +85,21 @@ export function useRemoveFromWatchlist() {
 }
 
 export function useWatchlist() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isInitialLoading } = useAuth();
   const queryClient = useQueryClient();
   const service = getWatchlistService(isAuthenticated);
   const addMutation = useAddToWatchlist();
   const removeMutation = useRemoveFromWatchlist();
 
-  const { data: likedMovies = [], isLoading, error } = useQuery({
+  const { data: likedMovies = [], isLoading: isQueryLoading, error } = useQuery({
     queryKey: queryKeys.watchlist.list(),
     queryFn: () => service.getWatchlist(),
     staleTime: isAuthenticated ? 1000 * 60 * 5 : Infinity,
     retry: false,
+    enabled: !isInitialLoading,
   });
+
+  const isLoading = isInitialLoading || isQueryLoading;
 
   const { data: rejectedMovies = [] } = useQuery({
     queryKey: queryKeys.watchlist.rejected(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
     "checkJs": false,
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@components/*": ["./src/components/*"],


### PR DESCRIPTION
## What

Fixes a race condition where the watchlist page showed "empty" for logged-in users because the watchlist query ran before the auth check completed, fetching from localStorage (guest) instead of the API.

## Changes

- race condition: gate watchlist query on `enabled: !isInitialLoading` so it waits for auth to resolve before selecting the service
- loading state: include `isInitialLoading` in the returned `isLoading` so the skeleton UI shows during the auth check instead of the empty state
- tsconfig: remove redundant `baseUrl` (paths work without it)

## Testing

- [ ] Tests pass locally
- [ ] Log in → reload → navigate to `/watchlist` — movies load correctly
- [ ] Confirm skeleton shows briefly during auth check (not "empty" state)
- [ ] Guest user sees empty state as before